### PR TITLE
Remove extra slash in generated urls.

### DIFF
--- a/src/teamworkProjects.ts
+++ b/src/teamworkProjects.ts
@@ -253,7 +253,7 @@ export class TeamworkProjects{
                     editor.edit(edit => {
                         edit.setEndOfLine(vscode.EndOfLine.CRLF);
                         edit.insert(new vscode.Position(line, cursor), commentWrapper + "Task: " + content + "\r\n");
-                        edit.insert(new vscode.Position(line, cursor), commentWrapper + "Link: " + root + "/tasks/" + id + "\r\n");
+                        edit.insert(new vscode.Position(line, cursor), commentWrapper + "Link: " + root + "tasks/" + id + "\r\n");
                         edit.insert(new vscode.Position(line, cursor), commentWrapper + "Assigned To: " + responsible + "\r\n"+ "\r\n");
                     });
                     


### PR DESCRIPTION
…4a66dece243

This removes an extra slash that shows up in the URL ("Link:") linking to the new TW Task. 

Here's a screenshot of the problem and solution in one shiny image: 
![image](https://user-images.githubusercontent.com/8559668/64489070-bb435e00-d203-11e9-9871-8f0bd2314989.png)
