### PR TITLE
Allow git to be toggled to “off” from a new default of “on”

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This extension contributes the following settings:
 * `twp.OnlySelfAssigned`    : Only show your own tasks
 * `twp.showUnAssigned`      : Show tasks assigned to "anyone" (default yes)
 * `twp.enabletimeTracking`  : Enable logging time and view entries on tasks (default yes)
+* `twp.ShowGitInfo`         : Add git information to newly created tasks (default yes)
 
 ## Linux users:
 * When you're using the add-in on Linux you need to use the old APIKey Login.

--- a/package.json
+++ b/package.json
@@ -59,6 +59,11 @@
 						"type": "boolean",
 						"description": "Show native teamwork panel (false: uses adaptive card )"
 					},
+					"twp.ShowGitInfo": {
+						"default": true,
+						"type": "boolean",
+						"description": "Add git information to newly created tasks"
+					},
 					"twp.enabletimeTracking": {
 						"default": true,
 						"type": "boolean",

--- a/src/teamworkProjects.ts
+++ b/src/teamworkProjects.ts
@@ -205,7 +205,10 @@ export class TeamworkProjects{
     
                 let gitLink = "";
                 let gitBranch = "";
-                try{
+                var config = vscode.workspace.getConfiguration('twp');
+                var gitUse = config.get("ShowGitInfo");
+                if (gitUse) {
+                  try{
                     const gitExtension = vscode.extensions.getExtension('vscode.git');
                     if( !isNullOrUndefined(gitExtension) ){
                         const gitExtension = vscode.extensions.getExtension('vscode.git').exports;
@@ -218,8 +221,9 @@ export class TeamworkProjects{
                             gitLink = gitLink.replace("ssh://git@","https://");
                         }
                      }
-                }catch(exception){
+                  }catch(exception){
 
+                  }                  
                 }
 
                 // creates a reference ID that won't change; because line number do.

--- a/src/teamworkProjects.ts
+++ b/src/teamworkProjects.ts
@@ -222,9 +222,13 @@ export class TeamworkProjects{
 
                 }
 
+                // creates a reference ID that won't change; because line number do.
+                let reference = Math.random().toString(36).substring(2, 15);
+
                 let taskDescription = "Task added from VSCode: \n";
                 taskDescription += "File: " + fileName + "\n";
                 taskDescription += "Line: " + line + "\n";
+                taskDescription += "Ref: " + reference + "\n";
                 if(gitBranch.length > 1) {taskDescription += "Branch:" + gitBranch + "\n";}
                 if(gitLink.length > 1) {taskDescription += "Link:" + gitLink + "\n";}
                 taskDescription += "Selection: " + "\n";
@@ -253,6 +257,7 @@ export class TeamworkProjects{
                     editor.edit(edit => {
                         edit.setEndOfLine(vscode.EndOfLine.CRLF);
                         edit.insert(new vscode.Position(line, cursor), commentWrapper + "Task: " + content + "\r\n");
+                        edit.insert(new vscode.Position(line, cursor), commentWrapper + "Ref: " + reference + "\r\n");
                         edit.insert(new vscode.Position(line, cursor), commentWrapper + "Link: " + root + "tasks/" + id + "\r\n");
                         edit.insert(new vscode.Position(line, cursor), commentWrapper + "Assigned To: " + responsible + "\r\n"+ "\r\n");
                     });

--- a/src/teamworkProjects.ts
+++ b/src/teamworkProjects.ts
@@ -253,7 +253,7 @@ export class TeamworkProjects{
                     editor.edit(edit => {
                         edit.setEndOfLine(vscode.EndOfLine.CRLF);
                         edit.insert(new vscode.Position(line, cursor), commentWrapper + "Task: " + content + "\r\n");
-                        edit.insert(new vscode.Position(line, cursor), commentWrapper + "Link: " + root + "/tasks/" + id + "\r\n");
+                        edit.insert(new vscode.Position(line, cursor), commentWrapper + "Link: " + root + "tasks/" + id + "\r\n");
                         edit.insert(new vscode.Position(line, cursor), commentWrapper + "Assigned To: " + responsible + "\r\n"+ "\r\n");
                     });
                     


### PR DESCRIPTION
Allows git information, that gets inserted into new TW tasks, to be turned off. 

The real problem in my case is that the git information showing up in the newly created tasks is wildly inaccurate — it shows info from an unrelated submodule instead of the git info from the root of the project I'm working in. 

Regardless I'd like to turn off all that git jazz — at least until the git root is optionally configurable from the extension instead of only autodetected.

Thanks guys!