### PR TITLE
Fix checklist formatting in PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -4,7 +4,7 @@ The creators and maintainers of this project are doing it with enthusiasm and ha
 
 ## Checklist
 
-- [ ] Changes include new automated tests covering them
-- [ ] You have tested the changes manually yourself
-- [ ] PR describes why you made the change, not just how
-- [ ] PR describes where where we should look to best understand changes & their effects (in code, in the resulting running software, elsewhere?)
+- [ ] Changes include new automated tests covering them.
+- [ ] You have tested the changes manually yourself.
+- [ ] PR describes why you made the change, not just how.
+- [ ] PR describes where where we should look to best understand changes & their effects (in code, in the resulting running software, elsewhere?).

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -4,7 +4,7 @@ The creators and maintainers of this project are doing it with enthusiasm and ha
 
 ## Checklist
 
-- [] changes include new automated tests covering them
-- [] have tested manually yourself
-- [] PR describes why you made the change, not just how
-- [] PR describes where where we should look to best understand changes & their effects (in code, in the resulting running software, elsewhere?)
+- [ ] Changes include new automated tests covering them
+- [ ] You have tested the changes manually yourself
+- [ ] PR describes why you made the change, not just how
+- [ ] PR describes where where we should look to best understand changes & their effects (in code, in the resulting running software, elsewhere?)


### PR DESCRIPTION
Currently "checklist" looks like this:

- [] changes include new automated tests covering them
- [] have tested manually yourself
- [] PR describes why you made the change, not just how
- [] PR describes where where we should look to best understand changes & their effects (in code, in the resulting running software, elsewhere?)

Spaces are required between brackets (or `x` for complete items) to render a checkbox:
- [ ] foo
- [x] bar