### PR TITLE
add missing slash in task urls

### DIFF
--- a/src/teamworkProjects.ts
+++ b/src/teamworkProjects.ts
@@ -262,7 +262,7 @@ export class TeamworkProjects{
                         edit.setEndOfLine(vscode.EndOfLine.CRLF);
                         edit.insert(new vscode.Position(line, cursor), commentWrapper + "Task: " + content + "\r\n");
                         edit.insert(new vscode.Position(line, cursor), commentWrapper + "Ref: " + reference + "\r\n");
-                        edit.insert(new vscode.Position(line, cursor), commentWrapper + "Link: " + root + "tasks/" + id + "\r\n");
+                        edit.insert(new vscode.Position(line, cursor), commentWrapper + "Link: " + root + "/tasks/" + id + "\r\n");
                         edit.insert(new vscode.Position(line, cursor), commentWrapper + "Assigned To: " + responsible + "\r\n"+ "\r\n");
                     });
                     


### PR DESCRIPTION
I requested that a slash be removed from the /tasks/ url over here => [branch: less-slash](https://github.com/perfectcube/vscode-projects/commit/6b77a03d02c52c857bf54d2200e1baf1eb920116) because [urls used to get generated with an extra "/" in them](https://github.com/Teamwork/vscode-projects/blob/1f81292b0fa92e2f8a1361d9d33d10c9ee60e317/src/teamworkProjects.ts#L254). 

It turns out I'll need that slash back.

Generated task urls are now getting chunked out into vscode like this: https://perfectcube.teamwork.comtasks/33364298 (_note_ tld is .**comtasks**) when they should be spat out like this https://perfectcube.teamwork.com/tasks/33364298.

Thanks for considering this change. 

# This is a Teamwork passion project and not officially supported by the team

The creators and maintainers of this project are doing it with enthusiasm and happiness, in odd moments between other projects and possibly even in their spare time. Please be kind to them, and understand that although they hope to get the time & energy to fix your bug :crossed_fingers:, this is not an officially supported product or service, and therefore doing so is not a part of their day jobs.

## Checklist

- [nope] Changes include new automated tests covering them.
- [but... it’s just a single slash] You have tested the changes manually yourself.
- [√] for not testing my change, I'm going to hell — aren’t I?!
- [√] PR describes why you made the change, not just how.
- [√] PR describes where where we should look to best understand changes & their effects (in code, in the resulting running software, elsewhere?).
